### PR TITLE
Windows Fixes

### DIFF
--- a/lumisync/sync/monitor.py
+++ b/lumisync/sync/monitor.py
@@ -10,6 +10,23 @@ from .. import connection, led_mapping, utils
 from ..config.options import BRIGHTNESS, GENERAL
 
 
+MISSING_CV2_MESSAGE = (
+    "Monitor sync requires OpenCV's cv2 module for Windows screen capture. "
+    "Install opencv-python-headless or use a LumiSync build that bundles it."
+)
+
+
+class ScreenCaptureDependencyError(RuntimeError):
+    """Raised when a required screen-capture dependency is unavailable."""
+
+
+def _create_dxcam_camera(dxcam_module, **kwargs):
+    try:
+        return dxcam_module.create(processor_backend="numpy", **kwargs)
+    except TypeError:
+        return dxcam_module.create(**kwargs)
+
+
 class ScreenGrab:
     """Facilitates taking a screenshot while supporting
     different platforms and compositors (the latter for Unix).
@@ -40,15 +57,22 @@ class ScreenGrab:
             if ScreenGrab._dxcam_instance is None:
                 requested_output = max(0, self.display_index)
                 try:
-                    self.camera = dxcam.create(output_idx=requested_output)
+                    self.camera = _create_dxcam_camera(
+                        dxcam,
+                        output_idx=requested_output,
+                    )
                 except Exception:
                     try:
-                        self.camera = dxcam.create(device_idx=0, output_idx=requested_output)
+                        self.camera = _create_dxcam_camera(
+                            dxcam,
+                            device_idx=0,
+                            output_idx=requested_output,
+                        )
                     except Exception:
                         # Fall back to dxcam's default output, usually the primary
                         # monitor. This keeps GUI sync usable when QSettings contains
                         # a stale or dxcam-incompatible display index.
-                        self.camera = dxcam.create()
+                        self.camera = _create_dxcam_camera(dxcam)
                         self.display_index = 0
                 ScreenGrab._dxcam_instance = self.camera
                 ScreenGrab._dxcam_output_idx = self.display_index
@@ -73,7 +97,12 @@ class ScreenGrab:
 
     def capture(self) -> Image.Image | None:
         """Captures a screenshot."""
-        screen = self.capture_method()
+        try:
+            screen = self.capture_method()
+        except ModuleNotFoundError as exc:
+            if exc.name == "cv2":
+                raise ScreenCaptureDependencyError(MISSING_CV2_MESSAGE) from exc
+            raise
         if screen is None:
             return screen
 
@@ -86,7 +115,11 @@ class ScreenGrab:
 def start(server: socket.socket, device: Dict[str, Any]) -> None:
     """Starts the monitor-light synchronization."""
     connection.switch_razer(server, device, True)
-    screen_grab = ScreenGrab()
+    try:
+        screen_grab = ScreenGrab()
+    except ScreenCaptureDependencyError as exc:
+        print(f"Monitor sync unavailable: {exc}")
+        return
 
     segment_count = connection.get_segment_count(device, default=10)
     previous_colors = [(0, 0, 0)] * segment_count
@@ -98,6 +131,9 @@ def start(server: socket.socket, device: Dict[str, Any]) -> None:
                 continue
 
             width, height = screen.size
+        except ScreenCaptureDependencyError as exc:
+            print(f"Monitor sync unavailable: {exc}")
+            return
         except OSError:
             print("Warning: Screenshot failed, trying again...")
             continue

--- a/packaging/pyinstaller/lumisync_onedir.spec
+++ b/packaging/pyinstaller/lumisync_onedir.spec
@@ -33,13 +33,16 @@ datas = [
 ]
 
 binaries = []
+binaries += safe_collect_dynamic_libs("cv2")
 binaries += safe_collect_dynamic_libs("dxcam")
 binaries += safe_collect_dynamic_libs("soundcard")
 
 hiddenimports = []
+hiddenimports += safe_collect_submodules("cv2")
 hiddenimports += safe_collect_submodules("lumisync")
 hiddenimports += safe_collect_submodules("dxcam")
 hiddenimports += [
+    "cv2",
     "PyQt6.QtCore",
     "PyQt6.QtGui",
     "PyQt6.QtSvg",

--- a/packaging/pyinstaller/lumisync_onefile.spec
+++ b/packaging/pyinstaller/lumisync_onefile.spec
@@ -33,13 +33,16 @@ datas = [
 ]
 
 binaries = []
+binaries += safe_collect_dynamic_libs("cv2")
 binaries += safe_collect_dynamic_libs("dxcam")
 binaries += safe_collect_dynamic_libs("soundcard")
 
 hiddenimports = []
+hiddenimports += safe_collect_submodules("cv2")
 hiddenimports += safe_collect_submodules("lumisync")
 hiddenimports += safe_collect_submodules("dxcam")
 hiddenimports += [
+    "cv2",
     "PyQt6.QtCore",
     "PyQt6.QtGui",
     "PyQt6.QtSvg",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
   "colorama>=0.4.6",
   "colour>=0.1.5",
-  "dxcam>=0.0.5",
+  "dxcam>=0.3.0",
   "matplotlib>=3.10.1",
   "numpy>=2.2.4",
   "packaging>=24.0",
@@ -30,6 +30,7 @@ dependencies = [
   "soundcard>=0.4.5",
   "webcolors>=24.11.1",
   "PyQt6>=6.6.0",
+  "opencv-python-headless>=4.10.0; sys_platform == 'win32'",
   "pywin32>=310; sys_platform == 'win32'",
   "mss>=10.1.0; sys_platform != 'win32'",
 ]

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -1,0 +1,86 @@
+import tomllib
+import unittest
+from pathlib import Path
+
+from lumisync.sync import monitor
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WindowsPackagingTests(unittest.TestCase):
+    def test_windows_capture_dependencies_include_cv2_provider(self):
+        pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+        dependencies = pyproject["project"]["dependencies"]
+
+        self.assertIn("dxcam>=0.3.0", dependencies)
+        self.assertTrue(
+            any(
+                dependency.startswith("opencv-python-headless>=")
+                and "sys_platform == 'win32'" in dependency
+                for dependency in dependencies
+            )
+        )
+
+    def test_pyinstaller_specs_bundle_cv2_lazy_import(self):
+        for spec_name in ("lumisync_onedir.spec", "lumisync_onefile.spec"):
+            with self.subTest(spec=spec_name):
+                spec = (
+                    ROOT / "packaging" / "pyinstaller" / spec_name
+                ).read_text()
+
+                self.assertIn('safe_collect_dynamic_libs("cv2")', spec)
+                self.assertIn('safe_collect_submodules("cv2")', spec)
+                self.assertIn('"cv2"', spec)
+
+    def test_dxcam_camera_prefers_numpy_processor_when_available(self):
+        class FakeDxcam:
+            def __init__(self):
+                self.calls = []
+
+            def create(self, **kwargs):
+                self.calls.append(kwargs)
+                return kwargs
+
+        fake_dxcam = FakeDxcam()
+
+        camera = monitor._create_dxcam_camera(fake_dxcam, output_idx=1)
+
+        self.assertEqual(camera["output_idx"], 1)
+        self.assertEqual(camera["processor_backend"], "numpy")
+
+    def test_dxcam_camera_supports_older_create_signature(self):
+        class FakeDxcam:
+            def __init__(self):
+                self.calls = []
+
+            def create(self, **kwargs):
+                self.calls.append(kwargs)
+                if "processor_backend" in kwargs:
+                    raise TypeError("unexpected keyword argument")
+                return kwargs
+
+        fake_dxcam = FakeDxcam()
+
+        camera = monitor._create_dxcam_camera(fake_dxcam, output_idx=1)
+
+        self.assertEqual(camera, {"output_idx": 1})
+        self.assertEqual(len(fake_dxcam.calls), 2)
+
+    def test_missing_cv2_raises_clear_capture_error(self):
+        screen_grab = monitor.ScreenGrab.__new__(monitor.ScreenGrab)
+
+        def missing_cv2():
+            raise ModuleNotFoundError("No module named 'cv2'", name="cv2")
+
+        screen_grab.capture_method = missing_cv2
+
+        with self.assertRaisesRegex(
+            monitor.ScreenCaptureDependencyError,
+            "opencv-python-headless",
+        ):
+            screen_grab.capture()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Fixed Monitor Sync crashing on Windows with ModuleNotFoundError: No module named 'cv2'.
- Added opencv-python-headless as a Windows dependency so dxcam has the screen-capture conversion module it needs.
- Updated Windows PyInstaller packaging so portable and onefile builds explicitly bundle OpenCV/cv2.
- Updated Monitor Sync capture setup to prefer dxcam’s NumPy processor path when available.
- Added a clearer error message if required screen-capture dependencies are missing, instead of showing a raw background-thread traceback.
- Added regression tests to catch missing Windows capture dependencies and missing PyInstaller cv2 bundling.